### PR TITLE
fix: show GitHub buttons only when repository is selected

### DIFF
--- a/frontend/__tests__/initial-query.test.tsx
+++ b/frontend/__tests__/initial-query.test.tsx
@@ -9,12 +9,12 @@ describe("Initial Query Behavior", () => {
   it("should clear initial query when clearInitialQuery is dispatched", () => {
     // Set up initial query in the store
     store.dispatch(setInitialQuery("test query"));
-    expect(store.getState().initalQuery.initialQuery).toBe("test query");
+    expect(store.getState().initialQuery.initialQuery).toBe("test query");
 
     // Clear the initial query
     store.dispatch(clearInitialQuery());
 
     // Verify initial query is cleared
-    expect(store.getState().initalQuery.initialQuery).toBeNull();
+    expect(store.getState().initialQuery.initialQuery).toBeNull();
   });
 });

--- a/frontend/src/components/features/chat/action-suggestions.tsx
+++ b/frontend/src/components/features/chat/action-suggestions.tsx
@@ -1,8 +1,10 @@
 import posthog from "posthog-js";
 import React from "react";
+import { useSelector } from "react-redux";
 import { SuggestionItem } from "#/components/features/suggestions/suggestion-item";
 import { useAuth } from "#/context/auth-context";
 import { DownloadModal } from "#/components/shared/download-modal";
+import type { RootState } from "#/store";
 
 interface ActionSuggestionsProps {
   onSuggestionsClick: (value: string) => void;
@@ -12,6 +14,9 @@ export function ActionSuggestions({
   onSuggestionsClick,
 }: ActionSuggestionsProps) {
   const { gitHubToken } = useAuth();
+  const { selectedRepository } = useSelector(
+    (state: RootState) => state.initialQuery,
+  );
 
   const [isDownloading, setIsDownloading] = React.useState(false);
   const [hasPullRequest, setHasPullRequest] = React.useState(false);
@@ -27,7 +32,7 @@ export function ActionSuggestions({
         onClose={handleDownloadClose}
         isOpen={isDownloading}
       />
-      {gitHubToken ? (
+      {gitHubToken && selectedRepository ? (
         <div className="flex flex-row gap-2 justify-center w-full">
           {!hasPullRequest ? (
             <>

--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -45,7 +45,7 @@ export function ChatInterface() {
   const [feedbackModalIsOpen, setFeedbackModalIsOpen] = React.useState(false);
   const [messageToSend, setMessageToSend] = React.useState<string | null>(null);
   const { selectedRepository, importedProjectZip } = useSelector(
-    (state: RootState) => state.initalQuery,
+    (state: RootState) => state.initialQuery,
   );
 
   const handleSendMessage = async (content: string, files: File[]) => {

--- a/frontend/src/components/features/controls/controls.tsx
+++ b/frontend/src/components/features/controls/controls.tsx
@@ -20,7 +20,7 @@ export function Controls({
 }: ControlsProps) {
   const { gitHubToken } = useAuth();
   const { selectedRepository } = useSelector(
-    (state: RootState) => state.initalQuery,
+    (state: RootState) => state.initialQuery,
   );
 
   const projectMenuCardData = React.useMemo(

--- a/frontend/src/components/features/project-menu/ProjectMenuCard.tsx
+++ b/frontend/src/components/features/project-menu/ProjectMenuCard.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import posthog from "posthog-js";
 import EllipsisH from "#/icons/ellipsis-h.svg?react";
-import { createChatMessage } from "#/services/chat-service";
 import { ProjectMenuCardContextMenu } from "./project.menu-card-context-menu";
 import { ProjectMenuDetailsPlaceholder } from "./project-menu-details-placeholder";
 import { ProjectMenuDetails } from "./project-menu-details";
-import { useWsClient } from "#/context/ws-client-provider";
 import { ConnectToGitHubModal } from "#/components/shared/modals/connect-to-github-modal";
 import { ModalBackdrop } from "#/components/shared/modals/modal-backdrop";
 import { DownloadModal } from "#/components/shared/download-modal";
@@ -23,8 +21,6 @@ export function ProjectMenuCard({
   isConnectedToGitHub,
   githubData,
 }: ProjectMenuCardProps) {
-  const { send } = useWsClient();
-
   const [contextMenuIsOpen, setContextMenuIsOpen] = React.useState(false);
   const [connectToGitHubModalOpen, setConnectToGitHubModalOpen] =
     React.useState(false);
@@ -32,26 +28,6 @@ export function ProjectMenuCard({
 
   const toggleMenuVisibility = () => {
     setContextMenuIsOpen((prev) => !prev);
-  };
-
-  const handlePushToGitHub = () => {
-    posthog.capture("push_to_github_button_clicked");
-    const rawEvent = {
-      content: `
-Please push the changes to GitHub and open a pull request.
-`,
-      imageUrls: [],
-      timestamp: new Date().toISOString(),
-      pending: false,
-    };
-    const event = createChatMessage(
-      rawEvent.content,
-      rawEvent.imageUrls,
-      rawEvent.timestamp,
-    );
-
-    send(event); // send to socket
-    setContextMenuIsOpen(false);
   };
 
   const handleDownloadWorkspace = () => {
@@ -69,7 +45,6 @@ Please push the changes to GitHub and open a pull request.
         <ProjectMenuCardContextMenu
           isConnectedToGitHub={isConnectedToGitHub}
           onConnectToGitHub={() => setConnectToGitHubModalOpen(true)}
-          onPushToGitHub={handlePushToGitHub}
           onDownloadWorkspace={handleDownloadWorkspace}
           onClose={() => setContextMenuIsOpen(false)}
         />

--- a/frontend/src/components/features/project-menu/project.menu-card-context-menu.tsx
+++ b/frontend/src/components/features/project-menu/project.menu-card-context-menu.tsx
@@ -7,7 +7,6 @@ import { I18nKey } from "#/i18n/declaration";
 interface ProjectMenuCardContextMenuProps {
   isConnectedToGitHub: boolean;
   onConnectToGitHub: () => void;
-  onPushToGitHub: () => void;
   onDownloadWorkspace: () => void;
   onClose: () => void;
 }
@@ -15,7 +14,6 @@ interface ProjectMenuCardContextMenuProps {
 export function ProjectMenuCardContextMenu({
   isConnectedToGitHub,
   onConnectToGitHub,
-  onPushToGitHub,
   onDownloadWorkspace,
   onClose,
 }: ProjectMenuCardContextMenuProps) {
@@ -29,11 +27,6 @@ export function ProjectMenuCardContextMenu({
       {!isConnectedToGitHub && (
         <ContextMenuListItem onClick={onConnectToGitHub}>
           {t(I18nKey.PROJECT_MENU_CARD_CONTEXT_MENU$CONNECT_TO_GITHUB_LABEL)}
-        </ContextMenuListItem>
-      )}
-      {isConnectedToGitHub && (
-        <ContextMenuListItem onClick={onPushToGitHub}>
-          {t(I18nKey.PROJECT_MENU_CARD_CONTEXT_MENU$PUSH_TO_GITHUB_LABEL)}
         </ContextMenuListItem>
       )}
       <ContextMenuListItem onClick={onDownloadWorkspace}>

--- a/frontend/src/components/shared/task-form.tsx
+++ b/frontend/src/components/shared/task-form.tsx
@@ -31,7 +31,7 @@ export const TaskForm = React.forwardRef<HTMLFormElement>((_, ref) => {
   const { settings } = useUserPrefs();
 
   const { selectedRepository, files } = useSelector(
-    (state: RootState) => state.initalQuery,
+    (state: RootState) => state.initialQuery,
   );
 
   const [text, setText] = React.useState("");

--- a/frontend/src/routes/_oh.app/hooks/use-handle-runtime-active.ts
+++ b/frontend/src/routes/_oh.app/hooks/use-handle-runtime-active.ts
@@ -26,7 +26,7 @@ export const useHandleRuntimeActive = () => {
   const runtimeActive = status === WsClientProviderStatus.ACTIVE;
 
   const { importedProjectZip } = useSelector(
-    (state: RootState) => state.initalQuery,
+    (state: RootState) => state.initialQuery,
   );
 
   const userId = React.useMemo(() => {

--- a/frontend/src/routes/_oh.app/hooks/use-ws-status-change.ts
+++ b/frontend/src/routes/_oh.app/hooks/use-ws-status-change.ts
@@ -8,11 +8,7 @@ import {
 import { createChatMessage } from "#/services/chat-service";
 import { setCurrentAgentState } from "#/state/agent-slice";
 import { addUserMessage } from "#/state/chat-slice";
-import {
-  clearSelectedRepository,
-  clearFiles,
-  clearInitialQuery,
-} from "#/state/initial-query-slice";
+import { clearFiles, clearInitialQuery } from "#/state/initial-query-slice";
 import { RootState } from "#/store";
 import AgentState from "#/types/agent-state";
 
@@ -24,11 +20,11 @@ export const useWSStatusChange = () => {
   const statusRef = React.useRef<WsClientProviderStatus | null>(null);
 
   const { selectedRepository } = useSelector(
-    (state: RootState) => state.initalQuery,
+    (state: RootState) => state.initialQuery,
   );
 
   const { files, importedProjectZip, initialQuery } = useSelector(
-    (state: RootState) => state.initalQuery,
+    (state: RootState) => state.initialQuery,
   );
 
   const sendInitialQuery = (query: string, base64Files: string[]) => {
@@ -51,7 +47,6 @@ export const useWSStatusChange = () => {
     let additionalInfo = "";
 
     if (gitHubToken && selectedRepository) {
-      dispatch(clearSelectedRepository());
       additionalInfo = `Repository ${selectedRepository} has been cloned to /workspace. Please check the /workspace for files.`;
     } else if (importedProjectZip) {
       // if there's an uploaded project zip, add it to the chat

--- a/frontend/src/routes/_oh.app/route.tsx
+++ b/frontend/src/routes/_oh.app/route.tsx
@@ -37,7 +37,7 @@ function AppContent() {
   useConversationConfig();
 
   const { selectedRepository } = useSelector(
-    (state: RootState) => state.initalQuery,
+    (state: RootState) => state.initialQuery,
   );
 
   const { updateCount } = useSelector((state: RootState) => state.browser);

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -12,7 +12,7 @@ import statusReducer from "./state/status-slice";
 
 export const rootReducer = combineReducers({
   fileState: fileStateReducer,
-  initalQuery: initialQueryReducer,
+  initialQuery: initialQueryReducer,
   browser: browserReducer,
   chat: chatReducer,
   code: codeReducer,


### PR DESCRIPTION
The Push to GitHub button was showing up whenever GitHub was connected, even if no specific repository was selected. This change ensures the button only appears when both conditions are met:

1. GitHub is connected
2. A specific repository is selected

This fixes the issue where the buttons would show up as long as you connect to GitHub, even without a specific repository connected.